### PR TITLE
Enable Extradite command in all relevant buffers

### DIFF
--- a/plugin/extradite.vim
+++ b/plugin/extradite.vim
@@ -12,7 +12,7 @@ if !exists('g:extradite_width')
     let g:extradite_width = 60
 endif
 
-command! -buffer -bang Extradite :execute s:Extradite(<bang>0)
+autocmd User Fugitive command! -buffer -bang Extradite :execute s:Extradite(<bang>0)
 
 autocmd Syntax extradite call s:ExtraditeSyntax()
 let g:extradite_bufnr = -1


### PR DESCRIPTION
Fugitive uses a User autocmd group to set up all buffer-local commands. Simply hook into this group for setting up the Extradite command so that it is available in more than just the first buffer.
