### PR TITLE
Set nomodeline before calling ExtraditeLoadCommitData

### DIFF
--- a/plugin/extradite.vim
+++ b/plugin/extradite.vim
@@ -32,7 +32,10 @@ function! s:Extradite(bang) abort
     let template_cmd = ['--no-pager', 'log', '-n100']
     let bufnr = bufnr('')
     let base_file_name = tempname()
+    let s:save_modeline = &modeline
+    set nomodeline
     call s:ExtraditeLoadCommitData(a:bang, base_file_name, template_cmd, path)
+    let &modeline = s:save_modeline
     let b:base_file_name = base_file_name
     let b:git_dir = git_dir
     let b:extradite_logged_bufnr = bufnr


### PR DESCRIPTION
The problem occurs when I have commit logs that start with vim: and so they look like a modeline.
This fixes the error
Error detected while processing function <SNR>16_Extradite..<SNR>16_ExtraditeLoadCommitData:
line   31:
E518: Unknown option: nnoremap 
