### PR TITLE
Disallow use of external diff

### DIFF
--- a/plugin/extradite.vim
+++ b/plugin/extradite.vim
@@ -237,7 +237,7 @@ function! s:SimpleDiff(a,b) abort
 
   setlocal modifiable
     silent! %delete _
-    let diff = system('git diff '.a:a.' '.a:b)
+    let diff = system('git diff --no-ext-diff '.a:a.' '.a:b)
     silent put = diff
   setlocal ft=diff buftype=nofile nomodifiable
 


### PR DESCRIPTION
If people have set their git config such that they use an external diff then it can cause Extradite not to function. 

This makes sure Extradite always uses git's own diff.

—Travis
