### PR TITLE
Print error message on empty list of log entries

### DIFF
--- a/plugin/extradite.vim
+++ b/plugin/extradite.vim
@@ -106,6 +106,11 @@ function! s:ExtraditeLoadCommitData(bang, base_file_name, template_cmd, ...) abo
     call add(extradata_list, {'commit': tokens[1], 'date': tokens[2]})
   endfor
 
+  if empty(extradata_list)
+    let v:errmsg = 'extradite: no log entries for the current file were found'
+    throw v:errmsg
+  endif
+
   if g:extradite_bufnr >= 0
     edit
   else


### PR DESCRIPTION
Without this fix I got a bunch of errors from Vim related to accessing nonexistent entries of `b:extradata_list` list. This happens on running `:Extradite` command in a file that is not part of a repository (e.g. ignored file).
