### PR TITLE
Better tabs support

### DIFF
--- a/plugin/extradite.vim
+++ b/plugin/extradite.vim
@@ -158,7 +158,7 @@ function! s:ExtraditeClose() abort
   if exists('b:extradite_simplediff_bufnr') && bufwinnr(b:extradite_simplediff_bufnr) >= 0
     exe 'keepjumps bd!' . b:extradite_simplediff_bufnr
   endif
-  keepjumps bd
+  exe b:extradite_logged_bufnr.'buffer'
   let logged_winnr = bufwinnr(extradite_logged_bufnr)
   if logged_winnr >= 0
     exe 'keepjumps '.logged_winnr.'wincmd w'


### PR DESCRIPTION
- Allow one Extradite buffer per tab page.
- Also includes a change that prevents tab page from being closed on quiting Extradite buffer.

Fixes #8. Well, implicitly, by switching from global variable to tab-variable.
